### PR TITLE
Add ability to start checker with npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js",
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js",
+    "start": "node start.js start"
   },
   "repository": {
     "type": "git",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,9 @@
+var program = require('commander')
+var cli = require('./lib/cli.js')
+
+program
+  .version('0.0.1')
+
+cli.standaloneCLI(program)
+if (process.argv.length === 2) program.help()
+program.parse(process.argv)


### PR DESCRIPTION
Copied from binder-web, to allow a common point of entry (npm start) for all binder components.